### PR TITLE
Support dotnet

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -107,7 +107,10 @@ if (program.ui) {
     });
 
   // start hosting
-  const hosting = spawnx(`${httpServerBin}`, `${app_artifact_location} -p ${appUriPort} -c-1 --proxy http://${program.host}:${program.port}/?`.split(" "));
+  const hosting = spawnx(
+    `${httpServerBin}`,
+    `${app_artifact_location} -p ${appUriPort} -c-1 --proxy http://${program.host}:${program.port}/?`.split(" ")
+  );
   dashboard.stream("hosting", hosting);
 
   // start functions

--- a/bin/index.js
+++ b/bin/index.js
@@ -6,6 +6,7 @@ const program = require("commander");
 const builder = require("../src/builder");
 const { readConfigFile } = require("../src/utils");
 const { spawn } = require("child_process");
+const { createRuntimeHost } = require("../src/runtimeHost");
 
 const EMU_PORT = 80;
 const AUTH_PORT = 4242;
@@ -67,6 +68,8 @@ const envVarsObj = {
   SWA_EMU_PORT: program.port,
 };
 
+const { command: hostCommand, args: hostArgs } = createRuntimeHost(appUriPort, program.host, program.port);
+
 const startCommand = [
   // run concurrent commands
   concurrentlyBin,
@@ -83,7 +86,7 @@ const startCommand = [
   // serve the app
   // See available options for http-server: https://github.com/http-party/http-server#available-options
   // Note: --proxy allows us to add fallback routes for SPA (https://github.com/http-party/http-server#catch-all-redirect)
-  `"${httpServerBin} ${app_artifact_location} -p ${appUriPort} -c-1 --proxy http://${program.host}:${program.port}/?"`,
+  `"${hostCommand} ${hostArgs.join(" ")}"`,
 
   // serve the api, if it's available
   `"[ -d '${api_location}' ] && (cd ${api_location}; func start --cors *) || echo 'No API found. Skipping.'"`,
@@ -107,10 +110,7 @@ if (program.ui) {
     });
 
   // start hosting
-  const hosting = spawnx(
-    `${httpServerBin}`,
-    `${app_artifact_location} -p ${appUriPort} -c-1 --proxy http://${program.host}:${program.port}/?`.split(" ")
-  );
+  const hosting = spawnx(hostCommand, hostArgs);
   dashboard.stream("hosting", hosting);
 
   // start functions

--- a/src/builder.js
+++ b/src/builder.js
@@ -23,27 +23,59 @@ const nodeBuilder = (location, buildCommand, name, colour) => {
   });
 };
 
+const dotnetBuilder = (location, name, colour) => {
+  const appBuildCommand = [
+    "CI=1",
+    concurrentlyBin,
+    `--names ${name}`,
+    `-c '${colour}'`,
+    `--kill-others-on-fail`,
+    `"dotnet build"`,
+    `--color=always`,
+  ].join(" ");
+  exec(appBuildCommand, {
+    cwd: location,
+  });
+};
+
 module.exports = () => {
   const { app_location, api_location, app_build_command, api_build_command } = readConfigFile();
   const runtimeType = detectRuntime(app_location);
 
   try {
     switch (runtimeType) {
+      case RuntimeType.dotnet:
+        {
+          // build app
+          dotnetBuilder(app_location, "app_build", "bgGreen.bold");
+
+          // NOTE: API is optional. Build it only if it exists
+          // This may result in a double-compile of some libraries if they are shared between the
+          // Blazor app and the API, but it's an acceptable outcome
+          let apiLocation = path.resolve(process.cwd(), api_location);
+          if (fs.existsSync(apiLocation) === true && fs.existsSync(path.join(apiLocation, "host.json"))) {
+            dotnetBuilder(apiLocation, "api_build", "bgYellow.bold");
+          }
+        }
+        break;
+
       case RuntimeType.node:
       default:
-        // figure out if appLocation exists
-        let appLocation = app_location;
-        if (fs.existsSync(appLocation) === false) {
-          appLocation = process.cwd();
-        }
+        {
+          // figure out if appLocation exists
+          let appLocation = app_location;
+          if (fs.existsSync(appLocation) === false) {
+            appLocation = process.cwd();
+          }
 
-        // build app
-        nodeBuilder(appLocation, app_build_command, "app_build", "bgGreen.bold");
+          // build app
+          nodeBuilder(appLocation, app_build_command, "app_build", "bgGreen.bold");
 
-        // NOTE: API is optional. Build it only if it exists
-        let apiLocation = path.resolve(process.cwd(), api_location);
-        if (fs.existsSync(apiLocation) === true && fs.existsSync(path.join(apiLocation, "host.json"))) {
-          nodeBuilder(apiLocation, api_build_command, "api_build", "bgYellow.bold");
+          // NOTE: API is optional. Build it only if it exists
+          let apiLocation = path.resolve(process.cwd(), api_location);
+          if (fs.existsSync(apiLocation) === true && fs.existsSync(path.join(apiLocation, "host.json"))) {
+            nodeBuilder(apiLocation, api_build_command, "api_build", "bgYellow.bold");
+          }
         }
         break;
     }

--- a/src/builder.js
+++ b/src/builder.js
@@ -1,52 +1,51 @@
 const fs = require("fs");
 const path = require("path");
 const shell = require("shelljs");
-const { readConfigFile } = require("./utils");
+const { readConfigFile, detectRuntime, RuntimeType } = require("./utils");
 
 const exec = (command, options = {}) => shell.exec(command, { async: false, ...options });
 
+// use the concurrently binary provided by this emulator
+const concurrentlyBin = path.resolve(__dirname, "..", "./node_modules/.bin/concurrently");
+
+const nodeBuilder = (location, buildCommand, name, colour) => {
+  const appBuildCommand = [
+    "CI=1",
+    concurrentlyBin,
+    `--names ${name}`,
+    `-c '${colour}'`,
+    `--kill-others-on-fail`,
+    `"npm install && ${buildCommand}"`,
+    `--color=always`,
+  ].join(" ");
+  exec(appBuildCommand, {
+    cwd: location,
+  });
+};
+
 module.exports = () => {
   const { app_location, api_location, app_build_command, api_build_command } = readConfigFile();
-
-  // use the concurrently binary provided by this emulator
-  const concurrentlyBin = path.resolve(__dirname, "..", "./node_modules/.bin/concurrently");
+  const runtimeType = detectRuntime(app_location);
 
   try {
-    // figure out if appLocation exists
-    let appLocation = app_location;
-    if (fs.existsSync(appLocation) === false) {
-      appLocation = process.cwd();
-    }
+    switch (runtimeType) {
+      case RuntimeType.node:
+      default:
+        // figure out if appLocation exists
+        let appLocation = app_location;
+        if (fs.existsSync(appLocation) === false) {
+          appLocation = process.cwd();
+        }
 
-    // build app
-    const appBuildCommand = [
-      'CI=1',
-      concurrentlyBin,
-      `--names app_build`,
-      `-c 'bgGreen.bold'`,
-      `--kill-others-on-fail`,
-      `"npm install && ${app_build_command}"`,
-      `--color=always`,
-    ].join(" ");
-    exec(appBuildCommand, {
-      cwd: appLocation,
-    });
+        // build app
+        nodeBuilder(appLocation, app_build_command, "app_build", "bgGreen.bold");
 
-    // NOTE: API is optional. Build it only if it exists
-    let apiLocation = path.resolve(process.cwd(), api_location);
-    if (fs.existsSync(apiLocation) === true && fs.existsSync(path.join(apiLocation, 'host.json'))) {
-      const apiBuildCommand = [
-        'CI=1',
-        concurrentlyBin,
-        `--names api_build`,
-        `--kill-others-on-fail`,
-        `-c 'bgYellow.bold'`,
-        `"npm install --production && ${api_build_command}"`,
-        `--color=always`,
-      ].join(" ");
-      exec(apiBuildCommand, {
-        cwd: apiLocation,
-      });
+        // NOTE: API is optional. Build it only if it exists
+        let apiLocation = path.resolve(process.cwd(), api_location);
+        if (fs.existsSync(apiLocation) === true && fs.existsSync(path.join(apiLocation, "host.json"))) {
+          nodeBuilder(apiLocation, api_build_command, "api_build", "bgYellow.bold");
+        }
+        break;
     }
   } catch (stderr) {
     console.error(stderr);

--- a/src/proxy.js
+++ b/src/proxy.js
@@ -64,6 +64,13 @@ const server = http.createServer(function (req, res) {
     processApiRequest(req, res);
   }
 
+  // detected a proxy pass-through from http-server, so 404 it
+  else if (req.url.startsWith("/?")) {
+    console.log("proxy>", req.method, req.headers.host + req.url);
+    const file404 = path.resolve(__dirname, "404.html");
+    serveStatic(file404, res);
+  }
+
   // proxy APP request to local APP
   else {
     const target = process.env.SWA_EMU_APP_URI || "http://localhost:4200";

--- a/src/proxy.js
+++ b/src/proxy.js
@@ -65,41 +65,43 @@ var server = http.createServer(function (req, res) {
       target,
       // set this to true so we can handle our own response
       // see https://github.com/http-party/node-http-proxy#miscellaneous
-      selfHandleResponse: true,
+      // selfHandleResponse: true,
     });
 
-    proxyApp.on("proxyRes", function (proxyRes, req, res) {
-      console.log("app>>>", req.method, target + req.url, `[${proxyRes.statusCode}]`);
+    // proxyApp.on("proxyRes", function (proxyRes, req, res) {
+    //   console.log("app>>>", req.method, target + req.url, `[${proxyRes.statusCode}]`);
 
-      const uri = url.parse(req.url).pathname;
-      // default to SWA 404 page
-      const file404 = path.resolve(__dirname, "404.html");
-      const fileIndex = path.join(process.env.SWA_EMU_APP_LOCATION, "index.html");
-      let resource = path.join(process.env.SWA_EMU_APP_LOCATION, req.url);
-      const isRouteRequest = (uri) => (uri.split("/").pop().indexOf(".") === -1 ? true : false);
+    //   const uri = url.parse(req.url).pathname;
+    //   // default to SWA 404 page
+    //   const file404 = path.resolve(__dirname, "404.html");
+    //   const fileIndex = path.join(process.env.SWA_EMU_APP_LOCATION, "index.html");
+    //   let resource = path.join(process.env.SWA_EMU_APP_LOCATION, req.url);
+    //   const isRouteRequest = (uri) => (uri.split("/").pop().indexOf(".") === -1 ? true : false);
 
-      // Not found, return the SWA 404 page
-      if (proxyRes.statusCode === 404) {
-        serveStatic(file404, res);
-        return;
-      }
+    //   // Not found, return the SWA 404 page
+    //   if (proxyRes.statusCode === 404) {
+    //     serveStatic(file404, res);
+    //     return;
+    //   }
 
-      // A request from the route.json file
-      if (isRouteRequest(uri)) {
-        serveStatic(fileIndex, res);
-        return;
-      }
+    //   // A request from the route.json file
+    //   if (isRouteRequest(uri)) {
+    //     serveStatic(fileIndex, res);
+    //     return;
+    //   }
 
-      // copy original response to proxy response
-      let body = [];
-      proxyRes.on("data", function (chunk) {
-        body.push(chunk);
-      });
-      proxyRes.on("end", function () {
-        body = Buffer.concat(body).toString();
-        res.end(body);
-      });
-    });
+    //   // copy original response to proxy response
+    //   const { rawHeaders } = proxyRes;
+    //   const headers = {};
+    //   for (let i = 0; i < rawHeaders.length; i += 2) {
+    //     let key = rawHeaders[i];
+    //     let val = rawHeaders[i + 1];
+
+    //     headers[key] = val;
+    //   }
+    //   res.writeHead(proxyRes.statusCode, headers);
+    //   proxyRes.pipe(res);
+    // });
 
     proxyApp.on("error", function (err, req, res) {
       console.log("app>>", req.method, target + req.url);

--- a/src/runtimeHost.js
+++ b/src/runtimeHost.js
@@ -17,7 +17,7 @@ module.exports.createRuntimeHost = (port, proxyHost, proxyPort) => {
     case RuntimeType.node:
     default:
       const command = httpServerBin;
-      const args = `${app_artifact_location} -p ${port} -c-1 --proxy http://${proxyHost}:${proxyPort}/?"`.split(" ");
+      const args = `${app_artifact_location} -p ${port} -c-1 --proxy http://${proxyHost}:${proxyPort}/?`.split(" ");
 
       return {
         command,

--- a/src/runtimeHost.js
+++ b/src/runtimeHost.js
@@ -1,0 +1,27 @@
+const path = require("path");
+const { readConfigFile } = require("./utils");
+const { detectRuntime, RuntimeType } = require("./runtimes");
+
+const httpServerBin = path.resolve(__dirname, "..", "./node_modules/.bin/http-server");
+module.exports.createRuntimeHost = (port, proxyHost, proxyPort) => {
+  const { app_location, app_artifact_location } = readConfigFile();
+  const runtimeType = detectRuntime(app_location);
+
+  switch (runtimeType) {
+    case RuntimeType.dotnet:
+      return {
+        command: "dotnet",
+        args: `watch --project ${app_location} run --urls=http://localhost:${port}`.split(" "),
+      };
+
+    case RuntimeType.node:
+    default:
+      const command = httpServerBin;
+      const args = `${app_artifact_location} -p ${port} -c-1 --proxy http://${proxyHost}:${proxyPort}/?"`.split(" ");
+
+      return {
+        command,
+        args,
+      };
+  }
+};

--- a/src/runtimes.js
+++ b/src/runtimes.js
@@ -1,0 +1,19 @@
+const path = require("path");
+const fs = require("fs");
+
+const RuntimeType = {
+  dotnet: "dotnet",
+  node: "node",
+};
+
+module.exports.RuntimeType = RuntimeType;
+
+module.exports.detectRuntime = (app_location) => {
+  const files = fs.readdirSync(app_location);
+
+  if (files.some((file) => path.extname(file) === ".csproj")) {
+    return RuntimeType.dotnet;
+  }
+
+  return RuntimeType.node;
+};

--- a/src/utils.js
+++ b/src/utils.js
@@ -74,6 +74,21 @@ module.exports.ɵɵUseGithubDevToken = async () => {
   return token.github;
 };
 
+module.exports.RuntimeType = {
+  dotnet: "dotnet",
+  node: "node",
+};
+
+module.exports.detectRuntime = (app_location) => {
+  const files = fs.readdirSync(app_location);
+
+  if (files.some((file) => path.extname(file) === ".csproj")) {
+    return module.exports.RuntimeType.dotnet;
+  }
+
+  return module.exports.RuntimeType.node;
+};
+
 module.exports.readConfigFile = () => {
   const githubActionFolder = path.resolve(process.cwd(), ".github/workflows/");
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -74,20 +74,24 @@ module.exports.ɵɵUseGithubDevToken = async () => {
   return token.github;
 };
 
-module.exports.RuntimeType = {
+const RuntimeType = {
   dotnet: "dotnet",
   node: "node",
 };
 
-module.exports.detectRuntime = (app_location) => {
+module.exports.RuntimeType = RuntimeType;
+
+const detectRuntime = (app_location) => {
   const files = fs.readdirSync(app_location);
 
   if (files.some((file) => path.extname(file) === ".csproj")) {
-    return module.exports.RuntimeType.dotnet;
+    return RuntimeType.dotnet;
   }
 
-  return module.exports.RuntimeType.node;
+  return RuntimeType.node;
 };
+
+module.exports.detectRuntime = detectRuntime;
 
 module.exports.readConfigFile = () => {
   const githubActionFolder = path.resolve(process.cwd(), ".github/workflows/");
@@ -127,7 +131,10 @@ module.exports.readConfigFile = () => {
     // these locations must be under the user's project folder
     app_location: path.join(process.cwd(), app_location),
     api_location: path.join(process.cwd(), api_location),
-    app_artifact_location: path.join(process.cwd(), app_location, app_artifact_location),
+    app_artifact_location:
+      detectRuntime(path.join(process.cwd(), app_location)) === RuntimeType.node
+        ? path.join(process.cwd(), app_location, app_artifact_location)
+        : path.join(process.cwd(), app_location, "bin", "Debug", "netstandard2.1", "publish", app_artifact_location),
   };
 
   return config;

--- a/src/utils.js
+++ b/src/utils.js
@@ -4,6 +4,7 @@ const path = require("path");
 const fs = require("fs");
 const shell = require("shelljs");
 const YAML = require("yaml");
+const { detectRuntime, RuntimeType } = require("./runtimes");
 
 module.exports.response = ({ context, status, headers, cookies, body = "" }) => {
   let location;
@@ -73,25 +74,6 @@ module.exports.ɵɵUseGithubDevToken = async () => {
   const token = await swaTokensResponse.json();
   return token.github;
 };
-
-const RuntimeType = {
-  dotnet: "dotnet",
-  node: "node",
-};
-
-module.exports.RuntimeType = RuntimeType;
-
-const detectRuntime = (app_location) => {
-  const files = fs.readdirSync(app_location);
-
-  if (files.some((file) => path.extname(file) === ".csproj")) {
-    return RuntimeType.dotnet;
-  }
-
-  return RuntimeType.node;
-};
-
-module.exports.detectRuntime = detectRuntime;
 
 module.exports.readConfigFile = () => {
   const githubActionFolder = path.resolve(process.cwd(), ".github/workflows/");


### PR DESCRIPTION
This PR supports dotnet as a SWA host environment, for doing blazor apps, but it also lays the groundwork to extend for other host runtimes going forward.

There is a bit of a rollback on the current functionality with regards to how the requests to the web host works. With a dotnet app, we rely on the Blazor dev server to handle some file pathing, which changes at publish (especially for auth). Also, since it's a compiled app, it's preferable to run the dotnet server, in watch mode, then just rely on the published files.

I've tested this with both blazor and JavaScript apps locally.