### PR TITLE
Packaging

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -25,3 +25,23 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - run: npm ci
     - run: npm test
+
+  package:
+    needs: [test]
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js 14.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14.x
+
+      - run: npm ci
+      - run: npm run build
+      - run: npm version prerelease --preid=ci-$GITHUB_RUN_ID --no-git-tag-version
+      - run: npm pack
+      - name: Upload
+        uses: actions/upload-artifact@v2
+        with:
+            name: package
+            path: "*.tgz"

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -61,7 +61,6 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: https://npm.pkg.github.com/
           scope: "@manekinekko"
-      - run: npm ci
       - run: echo "registry=https://npm.pkg.github.com/@manekinekko" >> .npmrc
       - run: npm publish $(ls *.tgz)
         env:

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -29,7 +29,6 @@ jobs:
   package:
     needs: [test]
     runs-on: ubuntu-18.04
-    # if: github.token != ''
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js 14.x
@@ -47,6 +46,12 @@ jobs:
             name: package
             path: "*.tgz"
 
+  publish:
+      name: "Publish to GitHub Packages"
+      needs: [package]
+      runs-on: ubuntu-18.04
+      if: github.repository_owner == 'manekinekko' # && github.token != ''
+      steps:
       - uses: actions/setup-node@v1
         with:
           node-version: ${{ env.NODE_VERSION }}

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -52,6 +52,10 @@ jobs:
       runs-on: ubuntu-18.04
       if: github.repository_owner == 'manekinekko' # && github.token != ''
       steps:
+      - name: Upload
+        uses: actions/download-artifact@v2
+        with:
+            name: package
       - uses: actions/setup-node@v1
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -59,6 +63,6 @@ jobs:
           scope: "@manekinekko"
       - run: npm ci
       - run: echo "registry=https://npm.pkg.github.com/@manekinekko" >> .npmrc
-      - run: npm publish
+      - run: npm publish $(ls *.tgz)
         env:
           NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -51,9 +51,9 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: https://npm.pkg.github.com/
-          scope: "@${{ github.repository_owner }}"
+          scope: "@manekinekko"
       - run: npm ci
-      - run: echo "registry=https://npm.pkg.github.com/@${{ github.repository_owner }}" >> .npmrc
+      - run: echo "registry=https://npm.pkg.github.com/@manekinekko" >> .npmrc
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -29,7 +29,7 @@ jobs:
   package:
     needs: [test]
     runs-on: ubuntu-18.04
-    if: github.token != ''
+    # if: github.token != ''
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js 14.x
@@ -46,3 +46,14 @@ jobs:
         with:
             name: package
             path: "*.tgz"
+
+      - uses: actions/setup-node@v1
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          registry-url: https://npm.pkg.github.com/
+          scope: "@${{ github.repository_owner }}"
+      - run: npm ci
+      - run: echo "registry=https://npm.pkg.github.com/@${{ github.repository_owner }}" >> .npmrc
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -29,6 +29,7 @@ jobs:
   package:
     needs: [test]
     runs-on: ubuntu-18.04
+    if: github.token != ''
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js 14.x

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ __pycache__/
 *$py.class
 
 dist
+*.tgz

--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,8 @@
 local.settings.json
+.vscode
+.github
+.release-it.json
+.editorconfig
+.tsconfig
+.nvmrc
+.prettierrc


### PR DESCRIPTION
This generates npm packages when a build runs. It'll first attach it as an artifact to the build job (so you could download and install it from the file) but it also pushes to GitHub Packages, so you can install it from there.

The package is versioned using the current semver of the `package.json` but then adds a prerelease of `-ci-<BuildId>` so it sits outside of the standard semver process being used.